### PR TITLE
Fix implicit pointer conversion in bt-device.c

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,7 +39,7 @@ AC_HEADER_STDC
 PKG_PROG_PKG_CONFIG
 
 PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.24.0])
-PKG_CHECK_MODULES([GIO], [gio-2.0 >= 2.26.0])
+PKG_CHECK_MODULES([GIO], [gio-2.0 >= 2.26.0 gio-unix-2.0 >= 2.26.0])
 
 # Check for the availability of libreadline
 AC_CHECK_HEADERS([readline/readline.h], [HAVE_READLINE_H=1])

--- a/src/bt-device.c
+++ b/src/bt-device.c
@@ -32,6 +32,7 @@
 
 #include <glib.h>
 #include <gio/gio.h>
+#include <gio/gunixinputstream.h>
 
 #include "lib/dbus-common.h"
 #include "lib/helpers.h"


### PR DESCRIPTION
Provide the right includes so gcc can know the right return type
instead of assuming an integer. This fix prevents the implicit
pointer conversion warning from happening (see [debian's implicity pointer conversion doc](https://wiki.debian.org/ImplicitPointerConversions) on why it is
good to avoid those kind of conversions).

bt-device.c was missing an include for gio/gunixinputstream.c.
configure.ac had to be updated to include gio-unix-2.0 module.

Fixes [Launchpad 1490204](https://bugs.launchpad.net/ubuntu/+source/bluez-tools/+bug/1490204) and [Debian 797356](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=797356).