### PR TITLE
remove incorrectly handled error argument from device_* calls in bt-device.c

### DIFF
--- a/src/bt-device.c
+++ b/src/bt-device.c
@@ -610,18 +610,18 @@ int main(int argc, char *argv[])
             exit(EXIT_FAILURE);
         }
 
-        g_print("[%s]\n", device_get_address(device, &error));
-        g_print("  Name: %s\n", device_get_name(device, &error));
-        g_print("  Alias: %s [rw]\n", device_get_alias(device, &error));
-        g_print("  Address: %s\n", device_get_address(device, &error));
-        g_print("  Icon: %s\n", device_get_icon(device, &error));
-        g_print("  Class: 0x%x\n", device_get_class(device, &error));
-        g_print("  Paired: %d\n", device_get_paired(device, &error));
-        g_print("  Trusted: %d [rw]\n", device_get_trusted(device, &error));
-        g_print("  Blocked: %d [rw]\n", device_get_blocked(device, &error));
-        g_print("  Connected: %d\n", device_get_connected(device, &error));
+        g_print("[%s]\n", device_get_address(device, NULL));
+        g_print("  Name: %s\n", device_get_name(device, NULL));
+        g_print("  Alias: %s [rw]\n", device_get_alias(device, NULL));
+        g_print("  Address: %s\n", device_get_address(device, NULL));
+        g_print("  Icon: %s\n", device_get_icon(device, NULL));
+        g_print("  Class: 0x%x\n", device_get_class(device, NULL));
+        g_print("  Paired: %d\n", device_get_paired(device, NULL));
+        g_print("  Trusted: %d [rw]\n", device_get_trusted(device, NULL));
+        g_print("  Blocked: %d [rw]\n", device_get_blocked(device, NULL));
+        g_print("  Connected: %d\n", device_get_connected(device, NULL));
         g_print("  UUIDs: [");
-        const gchar **uuids = device_get_uuids(device, &error);
+        const gchar **uuids = device_get_uuids(device, NULL);
         for (int j = 0; uuids[j] != NULL; j++)
         {
             if (j > 0) g_print(", ");


### PR DESCRIPTION
The '&error' argument should be handled and cleared if necessary. Otherwise
'device_*' calls might fail. If the 'device_get_uuids' call fails, the 'uuids' pointer
is NULL when dereferenced in the loop condition, causing a segfault.

Bad run:

```
$ bt-device  -i XX:XX:XX:XX:XX:XX
[XX:XX:XX:XX:XX:XX]
  Name: Ergonomic Keyboard
  Alias: Ergonomic Keyboard [rw]
  Address: XX:XX:XX:XX:XX:XX
  Icon: input-keyboard
  Class: 0x0

(bt-device:9732): GLib-GIO-CRITICAL **: 16:28:29.305: g_dbus_proxy_call_sync_internal: assertion 'error == NULL || *error == NULL' failed
  Paired: 0

(bt-device:9732): GLib-GIO-CRITICAL **: 16:28:29.305: g_dbus_proxy_call_sync_internal: assertion 'error == NULL || *error == NULL' failed
  Trusted: 0 [rw]

(bt-device:9732): GLib-GIO-CRITICAL **: 16:28:29.305: g_dbus_proxy_call_sync_internal: assertion 'error == NULL || *error == NULL' failed
  Blocked: 0 [rw]

(bt-device:9732): GLib-GIO-CRITICAL **: 16:28:29.305: g_dbus_proxy_call_sync_internal: assertion 'error == NULL || *error == NULL' failed
  Connected: 0
  UUIDs: [
(bt-device:9732): GLib-GIO-CRITICAL **: 16:28:29.305: g_dbus_proxy_call_sync_internal: assertion 'error == NULL || *error == NULL' failed
Segmentation fault (core dumped)
```

Fixed run:

```
$ src/bt-device  -i XX:XX:XX:XX:XX:XX
[XX:XX:XX:XX:XX:XX]
  Name: Ergonomic Keyboard
  Alias: Ergonomic Keyboard [rw]
  Address: XX:XX:XX:XX:XX:XX
  Icon: input-keyboard
  Class: 0x0
  Paired: 1
  Trusted: 0 [rw]
  Blocked: 0 [rw]
  Connected: 1
  UUIDs: [XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX, XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX, XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX, XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX, XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX]
```
