### PR TITLE
fix gcc-10 compile

### DIFF
--- a/src/lib/agent-helper.c
+++ b/src/lib/agent-helper.c
@@ -33,6 +33,8 @@
 
 #include "agent-helper.h"
 
+gboolean agent_need_unregister;
+
 static const gchar *_bt_agent_introspect_xml = "<node name=\"/org/blueztools\">\n\t<interface name=\"org.bluez.Agent1\">\n\t\t<method name=\"Release\">\n\t\t</method>\n\t\t<method name=\"RequestPinCode\">\n\t\t\t<arg name=\"device\" direction=\"in\" type=\"o\"/>\n\t\t\t<arg name=\"pincode\" direction=\"out\" type=\"s\"/>\n\t\t</method>\n\t\t<method name=\"DisplayPinCode\">\n\t\t\t<arg name=\"device\" direction=\"in\" type=\"o\"/>\n\t\t\t<arg name=\"pincode\" direction=\"in\" type=\"s\"/>\n\t\t</method>\n\t\t<method name=\"RequestPasskey\">\n\t\t\t<arg name=\"device\" direction=\"in\" type=\"o\"/>\n\t\t\t<arg name=\"passkey\" direction=\"out\" type=\"u\"/>\n\t\t</method>\n\t\t<method name=\"DisplayPasskey\">\n\t\t\t<arg name=\"device\" direction=\"in\" type=\"o\"/>\n\t\t\t<arg name=\"passkey\" direction=\"in\" type=\"u\"/>\n\t\t\t<arg name=\"entered\" direction=\"in\" type=\"q\"/>\n\t\t</method>\n\t\t<method name=\"RequestConfirmation\">\n\t\t\t<arg name=\"device\" direction=\"in\" type=\"o\"/>\n\t\t\t<arg name=\"passkey\" direction=\"in\" type=\"u\"/>\n\t\t</method>\n\t\t<method name=\"RequestAuthorization\">\n\t\t\t<arg name=\"device\" direction=\"in\" type=\"o\"/>\n\t\t</method>\n\t\t<method name=\"AuthorizeService\">\n\t\t\t<arg name=\"device\" direction=\"in\" type=\"o\"/>\n\t\t\t<arg name=\"uuid\" direction=\"in\" type=\"s\"/>\n\t\t</method>\n\t\t<method name=\"Cancel\">\n\t\t</method>\n\t</interface>\n</node>\n";
 static guint _bt_agent_registration_id = 0;
 static GHashTable *_pin_hash_table = NULL;

--- a/src/lib/agent-helper.h
+++ b/src/lib/agent-helper.h
@@ -35,7 +35,7 @@ extern "C" {
 #define AGENT_DBUS_INTERFACE "org.bluez.Agent1"
 #define AGENT_PATH "/org/blueztools"
 
-gboolean agent_need_unregister;
+extern gboolean agent_need_unregister;
 
 void register_agent_callbacks(gboolean interactive_console, GHashTable *pin_dictonary, gpointer main_loop_object, GError **error);
 void unregister_agent_callbacks(GError **error);


### PR DESCRIPTION
```
/usr/bin/ld: bt-agent.o:/builddir/build/BUILD/bluez-tools-7cb788c9c43facfd2d14ff50e16d6a19f033a6a7/src/lib/agent-helper.h:38: multiple definition of `agent_need_unregister'; lib/agent-helper.o:/builddir/build/BUILD/bluez-tools-7cb788c9c43facfd2d14ff50e16d6a19f033a6a7/src/lib/agent-helper.h:38: first defined here
collect2: error: ld returned 1 exit status
```