### PR TITLE
Correct the signal handler registration bt-agent

### DIFF
--- a/src/bt-agent.c
+++ b/src/bt-agent.c
@@ -274,9 +274,9 @@ int main(int argc, char *argv[])
 	}
 
 	/* Add SIGTERM/SIGINT/SIGUSR1 handlers */
-	g_unix_signal_add (SIGTERM, usr1_signal_handler, NULL);
+	g_unix_signal_add (SIGTERM, term_signal_handler, NULL);
 	g_unix_signal_add (SIGINT, term_signal_handler, NULL);
-	g_unix_signal_add (SIGUSR1, term_signal_handler, NULL);
+	g_unix_signal_add (SIGUSR1, usr1_signal_handler, NULL);
 
 	g_main_loop_run(mainloop);
 


### PR DESCRIPTION
Integration with systemd showed that the bt-agent was not terminating
on a SIGTERM being sent seems evident from the typo on the handler
registration for the TERM being assign to the usr1_handler.

Signed-off-by: Charles Hardin <charles.hardin@chargepoint.com>