### PR TITLE
make obex ls work

### DIFF
--- a/src/lib/bluez/obex/obex_file_transfer.c
+++ b/src/lib/bluez/obex/obex_file_transfer.c
@@ -207,9 +207,8 @@ GVariant *obex_file_transfer_list_folder(ObexFileTransfer *self, GError **error)
 	g_assert(OBEX_FILE_TRANSFER_IS(self));
 	GVariant *ret = NULL;
 	GVariant *proxy_ret = g_dbus_proxy_call_sync(self->priv->proxy, "ListFolder", NULL, G_DBUS_CALL_FLAGS_NONE, -1, NULL, error);
-	if (proxy_ret != NULL)
+	if (proxy_ret == NULL)
 		return NULL;
-	proxy_ret = g_variant_get_child_value(proxy_ret, 0);
 	ret = g_variant_ref_sink(proxy_ret);
 	g_variant_unref(proxy_ret);
 	return ret;

--- a/src/lib/bluez/obex/obex_file_transfer.h
+++ b/src/lib/bluez/obex/obex_file_transfer.h
@@ -31,7 +31,7 @@ extern "C" {
 #include <glib-object.h>
 
 #define OBEX_FILE_TRANSFER_DBUS_SERVICE "org.bluez.obex"
-#define OBEX_FILE_TRANSFER_DBUS_INTERFACE "org.bluez.obex.FileTransfer"
+#define OBEX_FILE_TRANSFER_DBUS_INTERFACE "org.bluez.obex.FileTransfer1"
 
 /*
  * Type macros


### PR DESCRIPTION
Note that the BlueZ 5.50 (maybe earlier?) file transfer interface is named org.bluez.obex.FileTransfer1.  This is also needed for #45.

```
$ bt-obex -f 58:B0:D4:93:00:7A
FTP session opened
> ls
file	235808	bt-obex
>
```