### PR TITLE
Fix memory leaks and other bugs

### DIFF
--- a/src/bt-device.c
+++ b/src/bt-device.c
@@ -331,9 +331,9 @@ static GHashTable *_bt_device_sdp_browse(const gchar *device_path, const gchar *
         }
         
         if(pattern == NULL || strlen(pattern) == 0)
-            execl("/bin/sdptool", "/bin/sdptool", "browse", "--xml", device_path, (char *) 0);
+            execlp("sdptool", "sdptool", "browse", "--xml", device_path, (char *) 0);
         else
-            execl("/bin/sdptool", "/bin/sdptool", "browse", "--xml", "--uuid", pattern, device_path, (char *) 0);
+            execlp("sdptool", "sdptool", "browse", "--xml", "--uuid", pattern, device_path, (char *) 0);
         
     }
     if(pid == -1)

--- a/src/bt-obex.c
+++ b/src/bt-obex.c
@@ -90,14 +90,22 @@ static void _obex_server_object_manager_handler(GDBusConnection *connection, con
             GVariant* session_variant = g_variant_lookup_value(properties, "Session", NULL);
 
             ObexTransferInfo *info = g_malloc0(sizeof(ObexTransferInfo));
-            info->filesize = g_variant_get_uint64(size_variant);
             info->status = g_strdup(g_variant_get_string(status_variant, NULL));
 
             ObexSession *session = obex_session_new(g_variant_get_string(session_variant, NULL));
             info->obex_root = g_strdup(obex_session_get_root(session, NULL));
             g_object_unref(session);
 
-            g_variant_unref(size_variant);
+            if (size_variant != NULL)
+            {
+                info->filesize = g_variant_get_uint64(size_variant);
+                g_variant_unref(size_variant);
+            }
+            else
+            {
+                info->filesize = 0;
+            }
+
             g_variant_unref(status_variant);
             g_variant_unref(session_variant);
             

--- a/src/bt-obex.c
+++ b/src/bt-obex.c
@@ -626,7 +626,7 @@ int main(int argc, char *argv[])
         mainloop = g_main_loop_new(NULL, FALSE);
 
         ObexClient *client = obex_client_new();
-        const gchar *session_path = obex_client_create_session(client, dst_address, device_dict, &error);
+        const gchar *session_path = obex_client_create_session(client, dst_address, g_variant_ref(device_dict), &error);
         exit_if_error(error);
         ObexSession *session = obex_session_new(session_path);
         ObexObjectPush *oop = obex_object_push_new(obex_session_get_dbus_object_path(session));

--- a/src/bt-obex.c
+++ b/src/bt-obex.c
@@ -213,15 +213,24 @@ static void _obex_opp_client_object_manager_handler(GDBusConnection *connection,
             g_hash_table_insert(_transfers, g_strdup(interface_object_path), t);
 
             ObexTransferInfo *info = g_malloc0(sizeof(ObexTransferInfo));
-            info->filesize = g_variant_get_uint64(g_variant_lookup_value(properties, "Size", NULL));
-            info->filename = g_strdup(g_variant_get_string(g_variant_lookup_value(properties, "Name", NULL), NULL));
-            info->status = g_strdup(g_variant_get_string(g_variant_lookup_value(properties, "Status", NULL), NULL));
-            ObexSession *session = obex_session_new(g_variant_get_string(g_variant_lookup_value(properties, "Session", NULL), NULL));
-            
+
+            GVariant* size_variant = g_variant_lookup_value(properties, "Size", NULL);
+            GVariant* name_variant = g_variant_lookup_value(properties, "Name", NULL);
+            GVariant* status_variant = g_variant_lookup_value(properties, "Status", NULL);
+            GVariant* session_variant = g_variant_lookup_value(properties, "Session", NULL);
+
+            info->filesize = g_variant_get_uint64(size_variant);
+            info->filename = g_variant_dup_string(name_variant, NULL);
+            info->status = g_variant_dup_string(status_variant, NULL);
+            ObexSession *session = obex_session_new(g_variant_get_string(session_variant, NULL));
             info->obex_root = g_strdup(obex_session_get_root(session, NULL));
-            
+
+            g_variant_unref(size_variant);
+            g_variant_unref(name_variant);
+            g_variant_unref(status_variant);
+            g_variant_unref(session_variant);
             g_object_unref(session);
-            
+
             g_hash_table_insert(_transfer_infos, g_strdup(interface_object_path), info);
             if(g_strcmp0(info->status, "queued") == 0)
                 g_print("[Transfer#%s] Waiting...\n", info->filename);

--- a/src/lib/helpers.c
+++ b/src/lib/helpers.c
@@ -242,7 +242,7 @@ Device *find_device(Adapter *adapter, const gchar *name, GError **error)
                     
                     if(g_variant_lookup(properties, "Address", "s", &address))
                     {
-                        if(g_strcmp0(g_ascii_strdown(address, -1), g_ascii_strdown(name, -1)) == 0)
+                        if(name && address && g_ascii_strcasecmp(address, name) == 0)
                         {
                             device = device_new(object_path);
                         }

--- a/src/lib/helpers.c
+++ b/src/lib/helpers.c
@@ -171,7 +171,7 @@ Adapter *find_adapter(const gchar *name, GError **error)
     else
     {
         // Try to find by name
-        const GPtrArray *adapters_list = manager_get_adapters(manager);
+        GPtrArray *adapters_list = manager_get_adapters(manager);
         g_assert(adapters_list != NULL);
         for (int i = 0; i < adapters_list->len; i++)
         {
@@ -193,6 +193,7 @@ Adapter *find_adapter(const gchar *name, GError **error)
             g_object_unref(adapter);
             adapter = NULL;
         }
+        g_ptr_array_unref(adapters_list);
     }
 
     g_object_unref(manager);

--- a/src/lib/helpers.c
+++ b/src/lib/helpers.c
@@ -159,52 +159,39 @@ Adapter *find_adapter(const gchar *name, GError **error)
 
     Manager *manager = g_object_new(MANAGER_TYPE, NULL);
 
-    // If name is null or empty - return default adapter
-    if (name == NULL || strlen(name) == 0)
+    // Try to find by id
+    adapter_path = (gchar *) manager_find_adapter(manager, name, error);
+
+    // Found
+    if (adapter_path)
     {
-        adapter_path = (gchar *) manager_default_adapter(manager, error);
-        if (adapter_path)
-        {
-            // adapter = g_object_new(ADAPTER_TYPE, "DBusObjectPath", adapter_path, NULL);
-            adapter = adapter_new(adapter_path);
-        }
+        // adapter = g_object_new(ADAPTER_TYPE, "DBusObjectPath", adapter_path, NULL);
+        adapter = adapter_new(adapter_path);
     }
     else
     {
-        // Try to find by id
-        adapter_path = (gchar *) manager_find_adapter(manager, name, error);
-
-        // Found
-        if (adapter_path)
+        // Try to find by name
+        const GPtrArray *adapters_list = manager_get_adapters(manager);
+        g_assert(adapters_list != NULL);
+        for (int i = 0; i < adapters_list->len; i++)
         {
+            adapter_path = g_ptr_array_index(adapters_list, i);
             // adapter = g_object_new(ADAPTER_TYPE, "DBusObjectPath", adapter_path, NULL);
             adapter = adapter_new(adapter_path);
-        }
-        else
-        {
-            // Try to find by name
-            const GPtrArray *adapters_list = manager_get_adapters(manager);
-            g_assert(adapters_list != NULL);
-            for (int i = 0; i < adapters_list->len; i++)
+            adapter_path = NULL;
+
+            if (g_strcmp0(name, adapter_get_name(adapter, error)) == 0)
             {
-                adapter_path = g_ptr_array_index(adapters_list, i);
-                // adapter = g_object_new(ADAPTER_TYPE, "DBusObjectPath", adapter_path, NULL);
-                adapter = adapter_new(adapter_path);
-                adapter_path = NULL;
-
-                if (g_strcmp0(name, adapter_get_name(adapter, error)) == 0)
+                if (*error)
                 {
-                    if (error)
-                    {
-                        g_error_free(*error);
-                        *error = NULL;
-                    }
-                    break;
+                    g_error_free(*error);
+                    *error = NULL;
                 }
-
-                g_object_unref(adapter);
-                adapter = NULL;
+                break;
             }
+
+            g_object_unref(adapter);
+            adapter = NULL;
         }
     }
 

--- a/src/lib/manager.c
+++ b/src/lib/manager.c
@@ -84,45 +84,6 @@ GVariant *manager_get_managed_objects(Manager *self, GError **error)
     return retVal;
 }
 
-const gchar *manager_default_adapter(Manager *self, GError **error)
-{
-    g_assert(MANAGER_IS(self));
-
-    GVariant *objects = NULL;
-    objects = manager_get_managed_objects(self, error);
-    if (objects == NULL)
-        return NULL;
-
-    const gchar *object_path;
-    GVariant *ifaces_and_properties;
-    GVariantIter i;
-
-    g_variant_iter_init(&i, objects);
-    while (g_variant_iter_next(&i, "{&o@a{sa{sv}}}", &object_path, &ifaces_and_properties))
-    {
-        const gchar *interface_name;
-        GVariant *properties;
-        GVariantIter ii;
-        g_variant_iter_init(&ii, ifaces_and_properties);
-        while (g_variant_iter_next(&ii, "{&s@a{sv}}", &interface_name, &properties))
-        {
-            if (g_strstr_len(g_ascii_strdown(interface_name, -1), -1, "adapter"))
-            {
-                const gchar *retVal = g_strdup(object_path);
-                g_variant_unref(properties);
-                g_variant_unref(ifaces_and_properties);
-                g_variant_unref(objects);
-                return retVal;
-            }
-            g_variant_unref(properties);
-        }
-        g_variant_unref(ifaces_and_properties);
-    }
-    g_variant_unref(objects);
-
-    return NULL;
-}
-
 const gchar *manager_find_adapter(Manager *self, const gchar *pattern, GError **error)
 {
     g_assert(MANAGER_IS(self));
@@ -136,7 +97,11 @@ const gchar *manager_find_adapter(Manager *self, const gchar *pattern, GError **
     GVariant *ifaces_and_properties;
     GVariantIter i;
 
-    gchar *pattern_lowercase = g_ascii_strdown(pattern, -1);
+    gchar *pattern_lowercase = NULL;
+    if (pattern != NULL)
+    {
+        pattern_lowercase = g_ascii_strdown(pattern, -1);
+    }
 
     g_variant_iter_init(&i, objects);
     gboolean still_looking = TRUE;
@@ -152,6 +117,12 @@ const gchar *manager_find_adapter(Manager *self, const gchar *pattern, GError **
             if (strstr(interface_name_lowercase, "adapter"))
             {
                 g_free(interface_name_lowercase);
+
+                if (!pattern_lowercase)
+                {
+                    still_looking = FALSE;
+                    break;
+                }
 
                 gchar *object_base_name_original = g_path_get_basename(object_path);
                 gchar *object_base_name = g_ascii_strdown(interface_name, -1);

--- a/src/lib/manager.c
+++ b/src/lib/manager.c
@@ -200,8 +200,11 @@ GPtrArray *manager_get_adapters(Manager *self)
         g_variant_iter_init(&ii, ifaces_and_properties);
         while (g_variant_iter_next(&ii, "{&s@a{sv}}", &interface_name, &properties))
         {
-            if (g_strstr_len(g_ascii_strdown(interface_name, -1), -1, "adapter"))
+            char* interface_name_lowercase = g_ascii_strdown(interface_name, -1);
+            if (strstr(interface_name_lowercase, "adapter"))
                 g_ptr_array_add(adapter_array, (gpointer) g_strdup(object_path));
+
+            g_free(interface_name_lowercase);
             g_variant_unref(properties);
         }
         g_variant_unref(ifaces_and_properties);

--- a/src/lib/manager.h
+++ b/src/lib/manager.h
@@ -54,7 +54,6 @@ extern "C" {
      * Method definitions.
      */
     GVariant *manager_get_managed_objects(Manager *self, GError **error);
-    const gchar *manager_default_adapter(Manager *self, GError **error);
     const gchar *manager_find_adapter(Manager *self, const gchar *pattern, GError **error);
     GPtrArray *manager_get_adapters(Manager *self);
     const gchar **manager_get_devices(Manager *self, const gchar *adapter_pattern);

--- a/src/lib/properties.c
+++ b/src/lib/properties.c
@@ -205,12 +205,12 @@ static void _properties_create_gdbus_proxy(Properties *self, GError **error)
 {
     if(self->priv->dbus_type && self->priv->dbus_service_name && self->priv->dbus_object_path)
     {
-        if(g_ascii_strcasecmp(g_ascii_strdown(self->priv->dbus_type, -1), "system") == 0)
+        if(g_ascii_strcasecmp(self->priv->dbus_type, "system") == 0)
         {
             g_assert(system_conn != NULL);
             self->priv->proxy = g_dbus_proxy_new_sync(system_conn, G_DBUS_PROXY_FLAGS_NONE, NULL, self->priv->dbus_service_name, self->priv->dbus_object_path, PROPERTIES_DBUS_INTERFACE, NULL, error);
         }
-        else if(g_ascii_strcasecmp(g_ascii_strdown(self->priv->dbus_type, -1), "session") == 0)
+        else if(g_ascii_strcasecmp(self->priv->dbus_type, "session") == 0)
         {
             g_assert(session_conn != NULL);
             self->priv->proxy = g_dbus_proxy_new_sync(session_conn, G_DBUS_PROXY_FLAGS_NONE, NULL, self->priv->dbus_service_name, self->priv->dbus_object_path, PROPERTIES_DBUS_INTERFACE, NULL, error);


### PR DESCRIPTION
This fixes memory leaks (including fixing #20), uses `g_hash_table_new_full` instead of `g_hash_table_new` to simplify some memory management, removes a bunch of annoying `GLib-CRITICAL` errors due to an unset GVariant and use-after-free's, and replaces `manager_default_adapter` with `manager_find_adapter(..., NULL, ...)`.

It also fixes sdptool when it isn't in /bin; it seems to have trouble parsing its output but it can find the binary.